### PR TITLE
tui: fix compact description for multi-output primitives

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -724,7 +724,7 @@ fn compact_knowledge_desc(msg: &str) -> String {
 		return String::new();
 	};
 	// Try to extract the value name — first word or primitive name
-	let val_name = if let Some(rest) = msg.strip_prefix("Output of ") {
+	let val_name = if let Some(idx) = msg.find(" of ") { let rest = &msg[idx + 4..];
 		rest.split('(').next().unwrap_or("?").to_string()
 	} else {
 		msg.split_whitespace().next().unwrap_or("?").to_string()


### PR DESCRIPTION
### Recommended PR Description
Before you hit **"Create pull request"**, I suggest pasting this into the description box. It proves your technical due diligence and makes it much easier for them to hit "Merge."

**Title:** `tui: fix compact description for multi-output primitives`

**Description:**
> This PR fixes a display bug in the TUI where deduction labels for multi-output primitives (like **HKDF** or **SPLIT**) were incorrectly rendered as "First via reconstruct" instead of "HKDF via reconstruct".
> 
> ### Root Cause
> The `compact_knowledge_desc` function in `src/tui.rs` only accounted for the literal prefix `"Output of "`. However, `info_output_text` (in `src/info.rs`) generates indexed prefixes like `"First output of "` for primitives where `has_single_output` is false.
> 
> ### The Fix
> I've updated the parsing logic to search for the `" of "` delimiter instead of a hardcoded prefix. This correctly extracts the primitive name regardless of whether it is a single or indexed output.
> 
> ### Affected Primitives
> * **HKDF:** `output: vec![1, 2, 3, 4, 5]`
> * **SPLIT:** `output: vec![1, 2, 3, 4, 5]`
> * **SHAMIR_SPLIT:** `output: vec![3]`

