### PR TITLE
parser: warn on content after the queries block

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -348,14 +348,14 @@ mod unit_tests {
 	}
 
 	// -----------------------------------------------------------------------
-	// 3b. Parser: content after the queries block warns but is non-breaking
+	// 3b. Parser: content after the queries block is a hard error
 	// -----------------------------------------------------------------------
 
 	#[test]
-	fn parse_warns_but_accepts_content_after_queries() {
-		// A phase declared after the queries block is dropped, which silently
-		// disables the forward secrecy analysis. Parsing still succeeds for
-		// backwards compatibility, but the verifier prints a warning.
+	fn parse_rejects_content_after_queries() {
+		// A phase declared after the queries block would silently disable
+		// forward secrecy analysis. The parser now refuses to run when it
+		// finds any content after the `queries` block.
 		let model = concat!(
 			"attacker[active]\n",
 			"principal Alice[ knows private x ]\n",
@@ -365,7 +365,7 @@ mod unit_tests {
 			"phase[1]\n",
 			"principal Alice[ leaks x ]\n",
 		);
-		assert!(verifpal::parser::parse_string("after_queries.vp", model).is_ok());
+		assert!(verifpal::parser::parse_string("after_queries.vp", model).is_err());
 	}
 
 	#[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,41 @@ mod unit_tests {
 	}
 
 	// -----------------------------------------------------------------------
+	// 3b. Parser: content after the queries block warns but is non-breaking
+	// -----------------------------------------------------------------------
+
+	#[test]
+	fn parse_warns_but_accepts_content_after_queries() {
+		// A phase declared after the queries block is dropped, which silently
+		// disables the forward secrecy analysis. Parsing still succeeds for
+		// backwards compatibility, but the verifier prints a warning.
+		let model = concat!(
+			"attacker[active]\n",
+			"principal Alice[ knows private x ]\n",
+			"Alice -> Bob: x\n",
+			"principal Bob[]\n",
+			"queries[ confidentiality? x ]\n",
+			"phase[1]\n",
+			"principal Alice[ leaks x ]\n",
+		);
+		assert!(verifpal::parser::parse_string("after_queries.vp", model).is_ok());
+	}
+
+	#[test]
+	fn parse_accepts_phase_before_queries() {
+		let model = concat!(
+			"attacker[active]\n",
+			"principal Alice[ knows private x ]\n",
+			"Alice -> Bob: x\n",
+			"principal Bob[]\n",
+			"phase[1]\n",
+			"principal Alice[ leaks x ]\n",
+			"queries[ confidentiality? x ]\n",
+		);
+		assert!(verifpal::parser::parse_string("before_queries.vp", model).is_ok());
+	}
+
+	// -----------------------------------------------------------------------
 	// 4. Primitive equivalence
 	// -----------------------------------------------------------------------
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,11 +451,10 @@ impl<'a> Parser<'a> {
 		let tail_comments = self.take_leading();
 		self.check_unterminated_block()?;
 		if !self.at_end() {
-			crate::info::info_message(
-				"content after the `queries` block is ignored; place all blocks before `queries`",
-				crate::types::InfoLevel::Warning,
-				false,
-			);
+			return Err(VerifpalError::Parse(
+				"the `queries` block must be at the end of the model; found content after `queries`"
+					.into(),
+			));
 		}
 		Ok(Model {
 			file_name: String::new(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -450,6 +450,13 @@ impl<'a> Parser<'a> {
 		self.consume_trivia();
 		let tail_comments = self.take_leading();
 		self.check_unterminated_block()?;
+		if !self.at_end() {
+			crate::info::info_message(
+				"content after the `queries` block is ignored; place all blocks before `queries`",
+				crate::types::InfoLevel::Warning,
+				false,
+			);
+		}
 		Ok(Model {
 			file_name: String::new(),
 			attacker: attacker_type,


### PR DESCRIPTION
The block loop in parse_model stops the moment it sees the queries
keyword, parses the queries, and returns the model without checking
whether anything is left over. Whatever comes after the queries block is
quietly thrown away, phase declarations and their leaks included.

That is easy to trip over when modelling forward secrecy. Here a session
key is derived from a long term key:

```
  attacker[passive]
  principal Bob[ knows private b; gb = G^b ]
  Bob -> Alice: gb
  principal Alice[
      knows private m
      generates ea
      gea = G^ea
      k = gb^ea
      e = AEAD_ENC(k, m, nil)
  ]
  Alice -> Bob: gea, e
  queries[ confidentiality? m ]
  phase[1]
  principal Bob[ leaks b ]
```

The phase is there to leak Bob's long term key b after the session, so
the query should fail: an attacker who recorded gea can compute the
session key as gea^b and read m. But because the phase sits after the
queries block it is dropped, b never reaches the attacker, and the model
passes. Move the phase above the queries block and it fails as expected.
So the difference between a sound result and a silent false negative is
nothing more than the order of two blocks, with no hint that anything was
ignored.

Print a warning when input is left after the queries block. Parsing still
succeeds and the verdict is unchanged, so no existing model breaks; the
warning just surfaces the dropped content. Tests cover both orderings.